### PR TITLE
[Style Guide] Use GFM code blocks

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -16,10 +16,12 @@ As Uncle Bob says:
 ### Attribution and header info
 Your file headers should contain useful information only. The file already has a name, as does the class, and your (clean, well named, hint hint) code documents itself.
 
-	//
-	//  Created by YOURNAME on CREATIONDATE.
-	//  Copyright (c) 2012-2015 Lyst. All rights reserved.
-	//
+```objective
+//
+//  Created by YOURNAME on CREATIONDATE.
+//  Copyright (c) 2012-2015 Lyst. All rights reserved.
+//
+```
 
 ### Pull Requests
 “Pull request diffs must be 500 lines or less. No large diffs are allowed.” - Square Register
@@ -50,41 +52,53 @@ Categories must group like functionality. Use new categories for new functionali
 ### Braces
 No conditionals shall be coded without braces (in order to prepare for Swift). 
 
-	if (conditional) {single.line.statement;}
-
-	if (conditional) {
-		multiple;
-		line;
-		statement;
-	}
+```objectivec
+if (conditional) {single.line.statement;}
+	
+if (conditional) {
+	multiple;
+	line;
+	statement;
+}
+```
 
 ### dot.notation
 We favour dot notation for properties, over square brackets, in order to prepare for Swift.
 
-	myObject.sizeProperty;
+```objectivec
+myObject.sizeProperty;
+```
 
-### \[dot.notation withMethods\]
+### `[dot.notation withMethods]`
 We favour dot notation for single property access before calling a methods on that property, over square brackets, in order to prepare for Swift.
 
-	[myObject.sizeProperty methodName]
+```objectivec
+[myObject.sizeProperty methodName]
+```
 
 ### Chaining
 We try to avoid chaining multiple methods or properties together. This makes code hard to comprehend and impossible to debug without changing the code first.
 
 This is not good practice
 
-	myObject.frame.size.width; 	// we have no idea what size is now
+```objectivec
+myObject.frame.size.width; 	// we have no idea what size is now
+```
 
 This is good practice
 
-	CGRect frame = myObject.frame;
-	CGSize frameSize = frame.size.
-	frameSize.width;
+```objectivec
+CGRect frame = myObject.frame;
+CGSize frameSize = frame.size.
+frameSize.width;
+```
 
-### \#define constant values
-\#defines for constant values should be replaced by the (type checker friendly) 
+### `#define` constant values
+`#defines` for constant values should be replaced by the (type checker friendly) 
 
-	const type name = value;
+```objectivec
+const type name = value;
+```
 
 ### Macros
 Where possible, macros should be avoided in favour of functions.  
@@ -93,20 +107,22 @@ They are easy to reason about, to step through in debug, and come with free type
 
 Use inline functions where you have performance concerns.
 
-### id
-Always avoid id whenever possible. It bypasses all of the compiler type safety checking goodness and encourages ‘clever’ thinking. 
+### `id`
+Always avoid `id` whenever possible. It bypasses all of the compiler type safety checking goodness and encourages ‘clever’ thinking. 
 
-### instancetype
-Always prefer instancetype over id for factory and init methods. 
+### `instancetype`
+Always prefer `instancetype` over `id` for factory and init methods. 
 
 This not only gives you better type safety at compile time, but can avoid some nasty gotchas.
 
 Favour initialisers for classes expressed as class methods. For example:
 
-	+(instancetype)classFactory
-	{
- 		return [[self alloc] init];
-	}
+```objectivec
++(instancetype)classFactory
+{
+	return [[self alloc] init];
+}
+```
 
 Caveat: beware of calling alloc with the specific class name (.e.g [MyClass alloc] init]). Doing so means, then we won’t be able to create subclasses.
 
@@ -118,72 +134,91 @@ Use our round64Helper, floor64Helper or ceil64Helper on pixel calculations.
 ### Self Retain Cycles
 To avoid self retain cycles, create a weak self outside the block: 
 
-	__weak typeof(self) weakSelf = self;
+```objectivec
+__weak typeof(self) weakSelf = self;
+```
 
 And then transform it to a strong one inside of the block:
 
-	__strong typeof(self) strongSelf = weakSelf;
+```objectivec
+__strong typeof(self) strongSelf = weakSelf;
+```
 
 then use strongSelf.whatever in your block. Not using a strong reference will cause a compiler error.
 
-### ! conditional statements
-In order to prepare for our migration to Swift, all future conditionals using the ! operator are to be avoided unless they act upon a true boolean ([https://developer.apple.com/library/prerelease/mac/documentation/Swift/Conceptual/Swift_Programming_Language/BasicOperators.html](developer.apple.com/library/prerelease/mac/documentation/Swift/Conceptual/Swift_Programming_Language/BasicOperators.html)).
+### `!` conditional statements
+In order to prepare for our migration to Swift, all future conditionals using the `!` operator are to be avoided unless they act upon a true boolean ([https://developer.apple.com/library/prerelease/mac/documentation/Swift/Conceptual/Swift_Programming_Language/BasicOperators.html](developer.apple.com/library/prerelease/mac/documentation/Swift/Conceptual/Swift_Programming_Language/BasicOperators.html)).
 
 This will not pass PR anymore:
 
-	NSObject *object = [some thing];
-	if(!object) { // }
+```objectivec
+NSObject *object = [some thing];
+if(!object) { // }
+```
 
 This will 
 
-	NSObject *object = [some thing];
-	if(object != nil) { // }
+```objectivec
+NSObject *object = [some thing];
+if(object != nil) { // }
+```
 
 As will this
 
-	BOOL success = [some thing];
-	if(!success) { // }
+```objectivec
+BOOL success = [some thing];
+if(!success) { // }
+```
 
 And this
 
-	BOOL success = [some thing];
-	if(success == NO) { // }
+```objectivec
+BOOL success = [some thing];
+if(success == NO) { // }
+```
 
 ### Literals
 We will favour the modern literal syntax (even though it’s just syntactic sugar) 
 
-	NSString *str = @”Hello”;
-	NSNumber *num = @1;
-	NSNumber *enumNum = @(LYNum);
+```objectivec
+NSString *str = @"Hello";
+NSNumber *num = @1;
+NSNumber *enumNum = @(LYNum);
 
-	NSObject *object = myDictionary[“MyKey”]
+NSObject *object = myDictionary["MyKey"]
+```
 
 We favour this because it produces cleaner, more expressive, code.
 
 ### Signedness
 We favour signed integers over unsigned integers, to harmonise our coding best practice with that of Swift and aid future interoperability between code bases (Swift and Objective-C in the same project).
 
-Specifically, use NSInteger whenever you need an integer value that is not of a specific byte size (and question why you need a specific byte size).
+Specifically, use `NSInteger` whenever you need an integer value that is not of a specific byte size (and question why you need a specific byte size).
 
-### nullability
-Always annotate pointers with nonnull or nullable. It is a requirement that you always annotate methods and properties that are pointers with either nonnull or nullable and you are encouraged to reject PR’s without them. 
-
+### `nullability`
+Always annotate pointers with `nonnull` or `nullable`. It is a requirement that you always annotate methods and properties that are pointers with either `nonnull` or `nullable` and you are encouraged to reject PR’s without them. 
 This improves clarity of intent, and allows the compiler to perform more checks on your code which will enable better bridging when we start blending Swift and Objective-C together.
 
 ### Readonly properties by default
 All properties should be readonly until they cannot be (for easier testing and less brittle code)
 
-	@property (nonatomic, copy, readonly) NSString *name;
+```objectivec
+@property (nonatomic, copy, readonly) NSString *name;
+```
 
 ### Nonatomic properties by default
 All properties should be nonatomic until they cannot be (for speed)
 
-	@property (nonatomic, copy, readonly) NSString *name;
+```objectivec
+@property (nonatomic, copy, readonly) NSString *name;
+```
 
 ### Copy properties for mutable types
-All NSString, NSDictionary and NSArray properties should be copy, not strong (to prevent being handed an NSMutable version which could then change)
+All `NSString`, `NSDictionary` and `NSArray` properties should be copy, not strong (to prevent being handed an NSMutable version which could then change)
 
-	@property (nonatomic, copy, readonly) NSString *name;
+```objectivec
+@property (nonatomic, copy, readonly) NSString *name;
+```
 
 ### When it is not good to use properties
 When they cause side effects, as Clang will warn you…
@@ -193,21 +228,23 @@ When they cause side effects, as Clang will warn you…
 ### Writing Tests
 Each test method should match this pattern
 
-	-(void)testThat…
-	{
+```objectivec
+-(void)testThat
+{
 	// given
 
 	// when
 
 	// then
-	}
+}
+```
 
 Then should have at most one assert since the whole method should be for a single test. Multiple asserts make it hard to discern the true nature of the test or it’s failures. 
 
 The exception to this rule is where the asserts are used in the given, in order to assert a good known state before the when actions.
 
 ### Pairing methods visually close
-In the case where we have methods that need another method: (e.g addObserver/removeObserver for Notification Centre) always have them visually close to ensure that we are not missing the pair (the removeObserver for example).
+In the case where we have methods that need another method: (e.g `addObserver`/`removeObserver` for Notification Centre) always have them visually close to ensure that we are not missing the pair (the `removeObserver` for example).
 
 ### Lyst iOS Team Definition Of “Done”
 When deciding whether to move a task from in progress to ready for review, consider this checklist as a way to be assured that you are, indeed, done. If you cannot answer yes to each item, you are probably not done.


### PR DESCRIPTION
This pull request switches to use code blocks with syntax highlighting. Along with also fixing some broken code which used fancy quotes for string literals (” instead of ").
